### PR TITLE
Fix: Init new setting values with current values.

### DIFF
--- a/ESPMaster/ESPMaster.ino
+++ b/ESPMaster/ESPMaster.ino
@@ -357,7 +357,7 @@ void setup() {
       
       long newMessageScheduleDateTimeUnixValue;
       bool newMessageScheduleEnabledValue, newMessageScheduleShowIndefinitely;
-      String newAlignmentValue, newDeviceModeValue, newFlapSpeedValue, newInputTextValue, newCountdownToDateUnixValue;
+      String newAlignmentValue = alignment, newDeviceModeValue = deviceMode, newFlapSpeedValue = flapSpeed, newInputTextValue = inputText, newCountdownToDateUnixValue = countdownToDateUnix;
       
       int params = request->params();
       for (int paramIndex = 0; paramIndex < params; paramIndex++) {


### PR DESCRIPTION
Init new setting values with current values, so that when only part of the settings are set through the request, the other values remains the same.